### PR TITLE
Read proxy configuration from system properties

### DIFF
--- a/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
@@ -124,6 +124,7 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 							this.headers));
 
 			HttpContext context = new BasicHttpContext();
+			clientBuilder.useSystemProperties();
 			httpclient = clientBuilder.build();
 
 			final ResponseContentSupplier response = executeRequest(httpclient, clientUtil, httpRequestBase, context);


### PR DESCRIPTION
Hello,

For our use case we need to reach Instana through a proxy.
As explained in the [HTTPClient documentation](https://hc.apache.org/httpcomponents-client-4.5.x/httpclient/apidocs/org/apache/http/impl/client/HttpClientBuilder.html) : 

> System properties will be taken into account when configuring the default implementations when useSystemProperties() method is called prior to calling build().

So this PR does exactly that :)
Nevertheless, maybe proxy configuration should be read from the Jenkins Instance's plugins proxy configuration rather than using system properties ?

Kind regards,