### PR TITLE
Scoped release markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ project types:
 To ingest a Release Marker into Instana you simply need to add 
 `releaseMarker` to your Pipeline script .
 
-There is one mandatory parameter `releaseName`
+There is one mandatory parameter `releaseName` and two optional parameters `serviceName` and `applicationName`.
 
 For example
 ```groovy
@@ -29,4 +29,21 @@ If you wish to create a release for a particular timestamp you can use the optio
 
 ```groovy
 releaseMarker releaseName: "Test Release ${currentBuild.number}", releaseStartTimestamp: "1564486446000"
+```
+
+To create a release scoped to a given service or application you can add the `serviceName` and/or `applicationName` as parameter
+
+```groovy
+// service scoped
+releaseMarker releaseName: "Release 4711", serviceName: "my-service"
+```
+
+```groovy
+// application scoped
+releaseMarker releaseName: "Release 4711", applicationName: "My Application"
+```
+
+```groovy
+// service and application scoped
+releaseMarker releaseName: "Release 4711", serviceName: "my-service", applicationName: "My Application"
 ```

--- a/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
@@ -62,6 +62,12 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		JSONObject jsonObject =  new JSONObject();
 		jsonObject.put("name", step.getReleaseName());
 		jsonObject.put("start", step.getReleaseStartTimestamp());
+		if (step.getServiceName() != null && !step.getServiceName().trim().isEmpty()) {
+			jsonObject.put("serviceName", step.getServiceName());
+		}
+		if (step.getApplicationName() != null && !step.getApplicationName().trim().isEmpty()) {
+			jsonObject.put("applicationName", step.getApplicationName());
+		}
 		String body = jsonObject.toString();
 		List<HttpRequestNameValuePair> headers = step.resolveHeaders();
 

--- a/src/main/java/jenkins/plugins/instana/ReleaseMarker.java
+++ b/src/main/java/jenkins/plugins/instana/ReleaseMarker.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -31,12 +32,25 @@ public class ReleaseMarker extends Builder {
 
 	private @Nonnull
 	String releaseName;
+	private String serviceName = DescriptorImpl.serviceName;
+	private String applicationName = DescriptorImpl.applicationName;
 	private String releaseStartTimestamp = DescriptorImpl.releaseStartTimestamp;
 	private String releaseEndTimestamp = DescriptorImpl.releaseEndTimestamp;
 
 	@DataBoundConstructor
 	public ReleaseMarker(@Nonnull String releaseName) {
 		this.releaseName = releaseName;
+	}
+
+	public ReleaseMarker(@Nonnull String releaseName, @Nullable String serviceName,
+						 @Nullable String applicationName) {
+		this.releaseName = releaseName;
+		if (serviceName != null) {
+			this.serviceName = serviceName;
+		}
+		if (applicationName != null) {
+			this.applicationName = applicationName;
+		}
 	}
 
 	@Nonnull
@@ -60,6 +74,24 @@ public class ReleaseMarker extends Builder {
 	@DataBoundSetter
 	public void setReleaseEndTimestamp(String releaseEndTimestamp) {
 		this.releaseEndTimestamp = releaseEndTimestamp;
+	}
+
+	public String getServiceName() {
+		return serviceName;
+	}
+
+	@DataBoundSetter
+	public void setServiceName(String serviceName) {
+		this.serviceName = serviceName;
+	}
+
+	public String getApplicationName() {
+		return applicationName;
+	}
+
+	@DataBoundSetter
+	public void setApplicationName(String applicationName) {
+		this.applicationName = applicationName;
 	}
 
 	@Initializer(before = InitMilestone.PLUGINS_STARTED)
@@ -106,6 +138,8 @@ public class ReleaseMarker extends Builder {
 	@Extension
 	public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 		public static final String releaseName = "";
+		public static final String serviceName = "";
+		public static final String applicationName = "";
 		public static final String releaseStartTimestamp = "";
 		public static final String releaseEndTimestamp = "";
 

--- a/src/main/java/jenkins/plugins/instana/ReleaseMarkerStep.java
+++ b/src/main/java/jenkins/plugins/instana/ReleaseMarkerStep.java
@@ -27,6 +27,8 @@ import jenkins.plugins.instana.util.HttpRequestNameValuePair;
 public final class ReleaseMarkerStep extends Step {
 
 	private String releaseName;
+	private String serviceName = DescriptorImpl.serviceName;
+	private String applicationName = DescriptorImpl.applicationName;
 	private String releaseStartTimestamp = DescriptorImpl.releaseStartTimestamp;
 	private String releaseEndTimestamp = DescriptorImpl.releaseEndTimestamp;
 
@@ -58,6 +60,24 @@ public final class ReleaseMarkerStep extends Step {
 		this.releaseEndTimestamp = releaseEndTimestamp;
 	}
 
+	public String getServiceName() {
+		return serviceName;
+	}
+
+	@DataBoundSetter
+	public void setServiceName(String serviceName) {
+		this.serviceName = serviceName;
+	}
+
+	public String getApplicationName() {
+		return applicationName;
+	}
+
+	@DataBoundSetter
+	public void setApplicationName(String applicationName) {
+		this.applicationName = applicationName;
+	}
+
 	@Override
 	public StepExecution start(StepContext stepContext) {
 		return new ReleaseMarkerStep.Execution(this, stepContext);
@@ -86,6 +106,8 @@ public final class ReleaseMarkerStep extends Step {
 	@Extension
 	public static final class DescriptorImpl extends StepDescriptor {
 		public static final String releaseName = ReleaseMarker.DescriptorImpl.releaseName;
+		public static final String serviceName = ReleaseMarker.DescriptorImpl.serviceName;
+		public static final String applicationName = ReleaseMarker.DescriptorImpl.applicationName;
 		public static final String releaseStartTimestamp = ReleaseMarker.DescriptorImpl.releaseStartTimestamp;
 		public static final String releaseEndTimestamp = ReleaseMarker.DescriptorImpl.releaseEndTimestamp;
 

--- a/src/main/resources/jenkins/plugins/instana/ReleaseMarker/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/ReleaseMarker/config.jelly
@@ -6,4 +6,10 @@
 	<f:entry field="releaseStartTimestamp" title="Start timestamp">
 		<f:textbox />
 	</f:entry>
+	<f:entry field="serviceName" title="Service name (optional)">
+		<f:textbox />
+	</f:entry>
+	<f:entry field="applicationName" title="Application name (optional)">
+		<f:textbox />
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/instana/ReleaseMarkerStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/ReleaseMarkerStep/config.jelly
@@ -6,4 +6,10 @@
 	<f:entry field="releaseStartTimestamp" title="Start timestamp">
 		<f:textbox />
 	</f:entry>
+	<f:entry field="serviceName" title="Service name (optional)">
+		<f:textbox />
+	</f:entry>
+	<f:entry field="applicationName" title="Application name (optional)">
+		<f:textbox />
+	</f:entry>
 </j:jelly>

--- a/src/test/java/jenkins/plugins/instana/Registers.java
+++ b/src/test/java/jenkins/plugins/instana/Registers.java
@@ -21,7 +21,7 @@ import jenkins.plugins.instana.ReleaseMarkerTestBase.SimpleHandler;
  */
 public class Registers {
 
-	static void registerReleaseEndpointChecker(final String name, final String timestamp, final String apiToken)
+	static void registerReleaseEndpointChecker(final String name, final String serviceName, final String applicationName, final String timestamp, final String apiToken)
 	{
 		registerHandler("/api/releases", HttpMode.POST,new SimpleHandler() {
 			@Override
@@ -30,6 +30,12 @@ public class Registers {
 				final JSONObject jsonObject = JSONObject.fromObject(body);
 				assertEquals(jsonObject.getString("name"),name);
 				assertEquals(jsonObject.getString("start"),timestamp);
+				if (serviceName != null) {
+					assertEquals(jsonObject.getString("serviceName"),serviceName);
+				}
+				if (applicationName != null) {
+					assertEquals(jsonObject.getString("applicationName"),applicationName);
+				}
 
 				Enumeration<String> authHeaders = request.getHeaders("Authorization");
 				String authHeaderValue = authHeaders.nextElement();
@@ -44,6 +50,11 @@ public class Registers {
 				body(response,200,ContentType.APPLICATION_JSON,jsonObject.toString());
 			}
 		});
+	}
+
+	static void registerReleaseEndpointChecker(final String name, final String timestamp, final String apiToken)
+	{
+		registerReleaseEndpointChecker(name, null, null, timestamp, apiToken);
 	}
 
 	static void registerAlways200()

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerRoundtripTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerRoundtripTest.java
@@ -21,4 +21,37 @@ public class ReleaseMarkerRoundtripTest {
 		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName");
 		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
 	}
+
+	@Test
+	public void testConfigRoundtripWithService() throws Exception
+	{
+		FreeStyleProject project = jenkins.createFreeStyleProject();
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", "testServiceName", null));
+		project = jenkins.configRoundtrip(project);
+
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", "testServiceName", null);
+		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
+	}
+
+	@Test
+	public void testConfigRoundtripWithApplication() throws Exception
+	{
+		FreeStyleProject project = jenkins.createFreeStyleProject();
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", null, "testApplicationName"));
+		project = jenkins.configRoundtrip(project);
+
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", null, "testApplicationName");
+		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
+	}
+
+	@Test
+	public void testConfigRoundtripWithServiceAndApplication() throws Exception
+	{
+		FreeStyleProject project = jenkins.createFreeStyleProject();
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", "testServiceName", "testApplicationName"));
+		project = jenkins.configRoundtrip(project);
+
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", "testServiceName", "testApplicationName");
+		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
+	}
 }

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerStepTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerStepTest.java
@@ -21,7 +21,7 @@ public class ReleaseMarkerStepTest extends ReleaseMarkerTestBase {
 	public TemporaryFolder folder = new TemporaryFolder();
 
 	@Test
-	public void correctStepDefinitonWithAllParamatersSetTest() throws Exception {
+	public void correctStepDefinitonWithParametersSetTest() throws Exception {
 		// Prepare the server
 		registerReleaseEndpointChecker("testReleaseName", "123456787689", TEST_API_TOKEN);
 
@@ -29,6 +29,28 @@ public class ReleaseMarkerStepTest extends ReleaseMarkerTestBase {
 		WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
 		proj.setDefinition(new CpsFlowDefinition(
 				"def response = releaseMarker releaseName: 'testReleaseName', releaseStartTimestamp: '123456787689' \n" +
+						"println('Status: '+response.status)\n" +
+						"println('Response: '+response.content)\n",
+				true));
+
+		// Execute the build
+		WorkflowRun run = proj.scheduleBuild2(0).get();
+
+		// Check expectations
+		j.assertBuildStatusSuccess(run);
+		j.assertLogContains("Status: 200", run);
+	}
+
+	@Test
+	public void correctStepDefinitonWithAllParametersSetTest() throws Exception {
+		// Prepare the server
+		registerReleaseEndpointChecker("testReleaseName", "testServiceName", "testApplicationName", "123456787689", TEST_API_TOKEN);
+
+		// Configure the build
+		WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
+		proj.setDefinition(new CpsFlowDefinition(
+				"def response = releaseMarker releaseName: 'testReleaseName', releaseStartTimestamp: '123456787689', " +
+						"serviceName: 'testServiceName', applicationName: 'testApplicationName' \n" +
 						"println('Status: '+response.status)\n" +
 						"println('Response: '+response.content)\n",
 				true));


### PR DESCRIPTION
# Why

The upcoming release of Instana will feature the possibility to have scoped release markers. The supported scopes are `applications` and `service`.

# What

Add the two new optional parameters named `serviceNames` and `applicationNames` to ReleaseMarker and ReleaseMarkerStep. Add test cases which cover cases with services and/or applications set.