### PR TITLE
Add optional services and applications to release markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ project types:
 To ingest a Release Marker into Instana you simply need to add 
 `releaseMarker` to your Pipeline script .
 
-There is one mandatory parameter `releaseName`
+There is one mandatory parameter `releaseName` and two optional parameters `serviceNames` and `applicationNames`.
 
 For example
 ```groovy
@@ -30,3 +30,16 @@ If you wish to create a release for a particular timestamp you can use the optio
 ```groovy
 releaseMarker releaseName: "Test Release ${currentBuild.number}", releaseStartTimestamp: "1564486446000"
 ```
+
+To create a release scoped to a given service or application you can add the `serviceNames` or `applicationNames` as parameter
+
+```groovy
+// service scoped
+releaseMarker releaseName: "Release 4711", serviceNames: ["my-service"]
+```
+
+```groovy
+// application scoped
+releaseMarker releaseName: "Release 4711", applicationNames: ["My Application"]
+```
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ project types:
 To ingest a Release Marker into Instana you simply need to add 
 `releaseMarker` to your Pipeline script .
 
-There is one mandatory parameter `releaseName` and two optional parameters `serviceNames` and `applicationNames`.
+There is one mandatory parameter `releaseName` and two optional parameters `services` and `applications`.
 
 For example
 ```groovy
@@ -31,15 +31,21 @@ If you wish to create a release for a particular timestamp you can use the optio
 releaseMarker releaseName: "Test Release ${currentBuild.number}", releaseStartTimestamp: "1564486446000"
 ```
 
-To create a release scoped to a given service or application you can add the `serviceNames` or `applicationNames` as parameter
+To create a release scoped to a given service or application you can add the `services` or `applications` as parameter
 
 ```groovy
-// service scoped
-releaseMarker releaseName: "Release 4711", serviceNames: ["my-service"]
+// service scoped, single service
+releaseMarker releaseName: "Release 4711", services: [service(name: "my-service")]
+
+// service scoped, multiple services
+releaseMarker releaseName: "Release 4711", services: [service(name: "my-service-1"), service(name: "my-service-2")]
 ```
 
 ```groovy
-// application scoped
-releaseMarker releaseName: "Release 4711", applicationNames: ["My Application"]
+// application scoped, single application
+releaseMarker releaseName: "Release 4711", applications: [application (name: "My Application")]
+
+// application scoped, multiple applications
+releaseMarker releaseName: "Release 4711", applications: [application (name: "My Application-1"), application (name: "My Application-2")]
 ```
 

--- a/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
@@ -51,21 +51,21 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		JSONObject jsonObject =  new JSONObject();
 		jsonObject.put("name", http.getReleaseName());
 		jsonObject.put("start", http.getReleaseStartTimestamp());
-		if (http.getServiceNames() != null) {
+		if (http.getServices() != null) {
 			List<JSONObject> services = new ArrayList<>();
-			for (Service serviceName : http.getServiceNames()) {
-				JSONObject service = new JSONObject();
-				service.put("name", serviceName.getName());
-				services.add(service);
+			for (Service service : http.getServices()) {
+				JSONObject serviceJson = new JSONObject();
+				serviceJson.put("name", service.getName());
+				services.add(serviceJson);
 			}
 			jsonObject.put("services", services);
 		}
-		if (http.getApplicationNames() != null) {
+		if (http.getApplications() != null) {
 			List<JSONObject> applications = new ArrayList<>();
-			for (Application applicationName : http.getApplicationNames()) {
-				JSONObject application = new JSONObject();
-				application.put("name", applicationName.getName());
-				applications.add(application);
+			for (Application application : http.getApplications()) {
+				JSONObject applicationJson = new JSONObject();
+				applicationJson.put("name", application.getName());
+				applications.add(applicationJson);
 			}
 			jsonObject.put("applications", applications);
 		}
@@ -82,21 +82,21 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		JSONObject jsonObject =  new JSONObject();
 		jsonObject.put("name", step.getReleaseName());
 		jsonObject.put("start", step.getReleaseStartTimestamp());
-		if (step.getServiceNames() != null) {
+		if (step.getServices() != null) {
 			List<JSONObject> services = new ArrayList<>();
-			for (String serviceName : step.getServiceNames()) {
-				JSONObject service = new JSONObject();
-				service.put("name", serviceName);
-				services.add(service);
+			for (Service service : step.getServices()) {
+				JSONObject serviceJson = new JSONObject();
+				serviceJson.put("name", service.getName());
+				services.add(serviceJson);
 			}
 			jsonObject.put("services", services);
 		}
-		if (step.getApplicationNames() != null) {
+		if (step.getApplications() != null) {
 			List<JSONObject> applications = new ArrayList<>();
-			for (String applicationName : step.getApplicationNames()) {
-				JSONObject application = new JSONObject();
-				application.put("name", applicationName);
-				applications.add(application);
+			for (Application application : step.getApplications()) {
+				JSONObject applicationJson = new JSONObject();
+				applicationJson.put("name", application.getName());
+				applications.add(applicationJson);
 			}
 			jsonObject.put("applications", applications);
 		}

--- a/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
@@ -9,6 +9,7 @@ import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 import net.sf.json.JSONObject;
@@ -48,8 +49,26 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		JSONObject jsonObject =  new JSONObject();
 		jsonObject.put("name", http.getReleaseName());
 		jsonObject.put("start", http.getReleaseStartTimestamp());
+		if (http.getServiceNames() != null) {
+			List<JSONObject> services = new ArrayList<>();
+			for (String serviceName : http.getServiceNames()) {
+				JSONObject service = new JSONObject();
+				service.put("name", serviceName);
+				services.add(service);
+			}
+			jsonObject.put("services", services);
+		}
+		if (http.getApplicationNames() != null) {
+			List<JSONObject> applications = new ArrayList<>();
+			for (String applicationName : http.getApplicationNames()) {
+				JSONObject service = new JSONObject();
+				service.put("name", applicationName);
+				applications.add(service);
+			}
+			jsonObject.put("applications", applications);
+		}
 		String body = jsonObject.toString();
-
+		System.out.println(body);
 		List<HttpRequestNameValuePair> headers = http.resolveHeaders();
 
 		return new HttpRequestExecution(url, http.resolveHttpMode(), body,
@@ -62,7 +81,26 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		JSONObject jsonObject =  new JSONObject();
 		jsonObject.put("name", step.getReleaseName());
 		jsonObject.put("start", step.getReleaseStartTimestamp());
+		if (step.getServiceNames() != null) {
+			List<JSONObject> services = new ArrayList<>();
+			for (String serviceName : step.getServiceNames()) {
+				JSONObject service = new JSONObject();
+				service.put("name", serviceName);
+				services.add(service);
+			}
+			jsonObject.put("services", services);
+		}
+		if (step.getApplicationNames() != null) {
+			List<JSONObject> applications = new ArrayList<>();
+			for (String applicationName : step.getApplicationNames()) {
+				JSONObject service = new JSONObject();
+				service.put("name", applicationName);
+				applications.add(service);
+			}
+			jsonObject.put("applications", applications);
+		}
 		String body = jsonObject.toString();
+		System.out.println(body);
 		List<HttpRequestNameValuePair> headers = step.resolveHeaders();
 
 		return new HttpRequestExecution(url, step.resolveHttpMode(), body,

--- a/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
@@ -61,14 +61,13 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		if (http.getApplicationNames() != null) {
 			List<JSONObject> applications = new ArrayList<>();
 			for (String applicationName : http.getApplicationNames()) {
-				JSONObject service = new JSONObject();
-				service.put("name", applicationName);
-				applications.add(service);
+				JSONObject application = new JSONObject();
+				application.put("name", applicationName);
+				applications.add(application);
 			}
 			jsonObject.put("applications", applications);
 		}
 		String body = jsonObject.toString();
-		System.out.println(body);
 		List<HttpRequestNameValuePair> headers = http.resolveHeaders();
 
 		return new HttpRequestExecution(url, http.resolveHttpMode(), body,
@@ -93,14 +92,13 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		if (step.getApplicationNames() != null) {
 			List<JSONObject> applications = new ArrayList<>();
 			for (String applicationName : step.getApplicationNames()) {
-				JSONObject service = new JSONObject();
-				service.put("name", applicationName);
-				applications.add(service);
+				JSONObject application = new JSONObject();
+				application.put("name", applicationName);
+				applications.add(application);
 			}
 			jsonObject.put("applications", applications);
 		}
 		String body = jsonObject.toString();
-		System.out.println(body);
 		List<HttpRequestNameValuePair> headers = step.resolveHeaders();
 
 		return new HttpRequestExecution(url, step.resolveHttpMode(), body,

--- a/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
@@ -25,6 +25,8 @@ import hudson.AbortException;
 import hudson.CloseProofOutputStream;
 import hudson.model.TaskListener;
 import hudson.remoting.RemoteOutputStream;
+import jenkins.plugins.instana.scope.Application;
+import jenkins.plugins.instana.scope.Service;
 import jenkins.plugins.instana.util.HttpClientUtil;
 import jenkins.plugins.instana.util.HttpRequestNameValuePair;
 import jenkins.plugins.instana.util.RequestAction;
@@ -51,18 +53,18 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 		jsonObject.put("start", http.getReleaseStartTimestamp());
 		if (http.getServiceNames() != null) {
 			List<JSONObject> services = new ArrayList<>();
-			for (String serviceName : http.getServiceNames()) {
+			for (Service serviceName : http.getServiceNames()) {
 				JSONObject service = new JSONObject();
-				service.put("name", serviceName);
+				service.put("name", serviceName.getName());
 				services.add(service);
 			}
 			jsonObject.put("services", services);
 		}
 		if (http.getApplicationNames() != null) {
 			List<JSONObject> applications = new ArrayList<>();
-			for (String applicationName : http.getApplicationNames()) {
+			for (Application applicationName : http.getApplicationNames()) {
 				JSONObject application = new JSONObject();
-				application.put("name", applicationName);
+				application.put("name", applicationName.getName());
 				applications.add(application);
 			}
 			jsonObject.put("applications", applications);

--- a/src/main/java/jenkins/plugins/instana/ReleaseMarker.java
+++ b/src/main/java/jenkins/plugins/instana/ReleaseMarker.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -28,15 +29,27 @@ import jenkins.plugins.instana.util.HttpRequestNameValuePair;
 
 public class ReleaseMarker extends Builder {
 
-
 	private @Nonnull
 	String releaseName;
+	private List<String> serviceNames = DescriptorImpl.serviceNames;
+	private List<String> applicationNames = DescriptorImpl.applicationNames;
 	private String releaseStartTimestamp = DescriptorImpl.releaseStartTimestamp;
 	private String releaseEndTimestamp = DescriptorImpl.releaseEndTimestamp;
 
 	@DataBoundConstructor
 	public ReleaseMarker(@Nonnull String releaseName) {
 		this.releaseName = releaseName;
+	}
+
+	public ReleaseMarker(@Nonnull String releaseName, @Nullable List<String> serviceNames,
+						 @Nullable List<String> applicationNames) {
+		this.releaseName = releaseName;
+		if (serviceNames != null) {
+			this.serviceNames = serviceNames;
+		}
+		if (applicationNames != null) {
+			this.applicationNames = applicationNames;
+		}
 	}
 
 	@Nonnull
@@ -60,6 +73,24 @@ public class ReleaseMarker extends Builder {
 	@DataBoundSetter
 	public void setReleaseEndTimestamp(String releaseEndTimestamp) {
 		this.releaseEndTimestamp = releaseEndTimestamp;
+	}
+
+	public List<String> getServiceNames() {
+		return serviceNames;
+	}
+
+	@DataBoundSetter
+	public void setServiceNames(List<String> serviceNames) {
+		this.serviceNames = serviceNames;
+	}
+
+	public List<String> getApplicationNames() {
+		return applicationNames;
+	}
+
+	@DataBoundSetter
+	public void setApplicationNames(List<String> applicationNames) {
+		this.applicationNames = applicationNames;
 	}
 
 	@Initializer(before = InitMilestone.PLUGINS_STARTED)
@@ -106,6 +137,8 @@ public class ReleaseMarker extends Builder {
 	@Extension
 	public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 		public static final String releaseName = "";
+		public static final List<String> serviceNames = null;
+		public static final List<String> applicationNames = null;
 		public static final String releaseStartTimestamp = "";
 		public static final String releaseEndTimestamp = "";
 

--- a/src/main/java/jenkins/plugins/instana/ReleaseMarker.java
+++ b/src/main/java/jenkins/plugins/instana/ReleaseMarker.java
@@ -33,8 +33,8 @@ public class ReleaseMarker extends Builder {
 
 	private @Nonnull
 	String releaseName;
-	private List<Service> serviceNames;
-	private List<Application> applicationNames;
+	private List<Service> services;
+	private List<Application> applications;
 	private String releaseStartTimestamp = DescriptorImpl.releaseStartTimestamp;
 	private String releaseEndTimestamp = DescriptorImpl.releaseEndTimestamp;
 
@@ -44,14 +44,14 @@ public class ReleaseMarker extends Builder {
 
 	@DataBoundConstructor
 	public ReleaseMarker(@Nonnull String releaseName,
-						 @Nullable List<Service> serviceNames,
-						 @Nullable List<Application> applicationNames) {
+						 @Nullable List<Service> services,
+						 @Nullable List<Application> applications) {
 		this.releaseName = releaseName;
-		if (serviceNames != null) {
-			this.serviceNames = serviceNames;
+		if (services != null) {
+			this.services = services;
 		}
-		if (applicationNames != null) {
-			this.applicationNames = applicationNames;
+		if (applications != null) {
+			this.applications = applications;
 		}
 	}
 
@@ -78,22 +78,22 @@ public class ReleaseMarker extends Builder {
 		this.releaseEndTimestamp = releaseEndTimestamp;
 	}
 
-	public List<Service> getServiceNames() {
-		return serviceNames;
+	public List<Service> getServices() {
+		return services;
 	}
 
 	@DataBoundSetter
-	public void setServiceNames(List<Service> serviceNames) {
-		this.serviceNames = serviceNames;
+	public void setServices(List<Service> services) {
+		this.services = services;
 	}
 
-	public List<Application> getApplicationNames() {
-		return applicationNames;
+	public List<Application> getApplications() {
+		return applications;
 	}
 
 	@DataBoundSetter
-	public void setApplicationNames(List<Application> applicationNames) {
-		this.applicationNames = applicationNames;
+	public void setApplications(List<Application> applications) {
+		this.applications = applications;
 	}
 
 	@Initializer(before = InitMilestone.PLUGINS_STARTED)
@@ -140,8 +140,8 @@ public class ReleaseMarker extends Builder {
 	@Extension
 	public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 		public static final String releaseName = "";
-		public static final List<String> serviceNames = null;
-		public static final List<String> applicationNames = null;
+		public static final List<Service> services = null;
+		public static final List<Application> applications = null;
 		public static final String releaseStartTimestamp = "";
 		public static final String releaseEndTimestamp = "";
 

--- a/src/main/java/jenkins/plugins/instana/ReleaseMarker.java
+++ b/src/main/java/jenkins/plugins/instana/ReleaseMarker.java
@@ -25,24 +25,27 @@ import hudson.model.Items;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
+import jenkins.plugins.instana.scope.Application;
+import jenkins.plugins.instana.scope.Service;
 import jenkins.plugins.instana.util.HttpRequestNameValuePair;
 
 public class ReleaseMarker extends Builder {
 
 	private @Nonnull
 	String releaseName;
-	private List<String> serviceNames = DescriptorImpl.serviceNames;
-	private List<String> applicationNames = DescriptorImpl.applicationNames;
+	private List<Service> serviceNames;
+	private List<Application> applicationNames;
 	private String releaseStartTimestamp = DescriptorImpl.releaseStartTimestamp;
 	private String releaseEndTimestamp = DescriptorImpl.releaseEndTimestamp;
 
-	@DataBoundConstructor
 	public ReleaseMarker(@Nonnull String releaseName) {
 		this.releaseName = releaseName;
 	}
 
-	public ReleaseMarker(@Nonnull String releaseName, @Nullable List<String> serviceNames,
-						 @Nullable List<String> applicationNames) {
+	@DataBoundConstructor
+	public ReleaseMarker(@Nonnull String releaseName,
+						 @Nullable List<Service> serviceNames,
+						 @Nullable List<Application> applicationNames) {
 		this.releaseName = releaseName;
 		if (serviceNames != null) {
 			this.serviceNames = serviceNames;
@@ -75,21 +78,21 @@ public class ReleaseMarker extends Builder {
 		this.releaseEndTimestamp = releaseEndTimestamp;
 	}
 
-	public List<String> getServiceNames() {
+	public List<Service> getServiceNames() {
 		return serviceNames;
 	}
 
 	@DataBoundSetter
-	public void setServiceNames(List<String> serviceNames) {
+	public void setServiceNames(List<Service> serviceNames) {
 		this.serviceNames = serviceNames;
 	}
 
-	public List<String> getApplicationNames() {
+	public List<Application> getApplicationNames() {
 		return applicationNames;
 	}
 
 	@DataBoundSetter
-	public void setApplicationNames(List<String> applicationNames) {
+	public void setApplicationNames(List<Application> applicationNames) {
 		this.applicationNames = applicationNames;
 	}
 
@@ -165,5 +168,4 @@ public class ReleaseMarker extends Builder {
 			}
 		}
 	}
-
 }

--- a/src/main/java/jenkins/plugins/instana/ReleaseMarkerStep.java
+++ b/src/main/java/jenkins/plugins/instana/ReleaseMarkerStep.java
@@ -22,13 +22,15 @@ import hudson.AbortException;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.TaskListener;
+import jenkins.plugins.instana.scope.Application;
+import jenkins.plugins.instana.scope.Service;
 import jenkins.plugins.instana.util.HttpRequestNameValuePair;
 
 public final class ReleaseMarkerStep extends Step {
 
 	private String releaseName;
-	private List<String> serviceNames = DescriptorImpl.serviceNames;
-	private List<String> applicationNames = DescriptorImpl.applicationNames;
+	private List<Service> services = DescriptorImpl.services;
+	private List<Application> applications = DescriptorImpl.applications;
 	private String releaseStartTimestamp = DescriptorImpl.releaseStartTimestamp;
 	private String releaseEndTimestamp = DescriptorImpl.releaseEndTimestamp;
 
@@ -60,22 +62,22 @@ public final class ReleaseMarkerStep extends Step {
 		this.releaseEndTimestamp = releaseEndTimestamp;
 	}
 
-	public List<String> getServiceNames() {
-		return serviceNames;
+	public List<Service> getServices() {
+		return services;
 	}
 
 	@DataBoundSetter
-	public void setServiceNames(List<String> serviceNames) {
-		this.serviceNames = serviceNames;
+	public void setServices(List<Service> services) {
+		this.services = services;
 	}
 
-	public List<String> getApplicationNames() {
-		return applicationNames;
+	public List<Application> getApplications() {
+		return applications;
 	}
 
 	@DataBoundSetter
-	public void setApplicationNames(List<String> applicationNames) {
-		this.applicationNames = applicationNames;
+	public void setApplications(List<Application> applications) {
+		this.applications = applications;
 	}
 
 	@Override
@@ -106,8 +108,8 @@ public final class ReleaseMarkerStep extends Step {
 	@Extension
 	public static final class DescriptorImpl extends StepDescriptor {
 		public static final String releaseName = ReleaseMarker.DescriptorImpl.releaseName;
-		public static final List<String> serviceNames = ReleaseMarker.DescriptorImpl.serviceNames;
-		public static final List<String> applicationNames = ReleaseMarker.DescriptorImpl.applicationNames;
+		public static final List<Service> services = ReleaseMarker.DescriptorImpl.services;
+		public static final List<Application> applications = ReleaseMarker.DescriptorImpl.applications;
 		public static final String releaseStartTimestamp = ReleaseMarker.DescriptorImpl.releaseStartTimestamp;
 		public static final String releaseEndTimestamp = ReleaseMarker.DescriptorImpl.releaseEndTimestamp;
 

--- a/src/main/java/jenkins/plugins/instana/ReleaseMarkerStep.java
+++ b/src/main/java/jenkins/plugins/instana/ReleaseMarkerStep.java
@@ -27,6 +27,8 @@ import jenkins.plugins.instana.util.HttpRequestNameValuePair;
 public final class ReleaseMarkerStep extends Step {
 
 	private String releaseName;
+	private List<String> serviceNames = DescriptorImpl.serviceNames;
+	private List<String> applicationNames = DescriptorImpl.applicationNames;
 	private String releaseStartTimestamp = DescriptorImpl.releaseStartTimestamp;
 	private String releaseEndTimestamp = DescriptorImpl.releaseEndTimestamp;
 
@@ -58,6 +60,24 @@ public final class ReleaseMarkerStep extends Step {
 		this.releaseEndTimestamp = releaseEndTimestamp;
 	}
 
+	public List<String> getServiceNames() {
+		return serviceNames;
+	}
+
+	@DataBoundSetter
+	public void setServiceNames(List<String> serviceNames) {
+		this.serviceNames = serviceNames;
+	}
+
+	public List<String> getApplicationNames() {
+		return applicationNames;
+	}
+
+	@DataBoundSetter
+	public void setApplicationNames(List<String> applicationNames) {
+		this.applicationNames = applicationNames;
+	}
+
 	@Override
 	public StepExecution start(StepContext stepContext) {
 		return new ReleaseMarkerStep.Execution(this, stepContext);
@@ -86,6 +106,8 @@ public final class ReleaseMarkerStep extends Step {
 	@Extension
 	public static final class DescriptorImpl extends StepDescriptor {
 		public static final String releaseName = ReleaseMarker.DescriptorImpl.releaseName;
+		public static final List<String> serviceNames = ReleaseMarker.DescriptorImpl.serviceNames;
+		public static final List<String> applicationNames = ReleaseMarker.DescriptorImpl.applicationNames;
 		public static final String releaseStartTimestamp = ReleaseMarker.DescriptorImpl.releaseStartTimestamp;
 		public static final String releaseEndTimestamp = ReleaseMarker.DescriptorImpl.releaseEndTimestamp;
 

--- a/src/main/java/jenkins/plugins/instana/scope/Application.java
+++ b/src/main/java/jenkins/plugins/instana/scope/Application.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.instana.scope;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
@@ -19,6 +20,7 @@ public class Application extends AbstractDescribableImpl<Application> {
 		return name;
 	}
 
+	@Symbol("application")
 	@Extension
 	public static final class DescriptorImpl extends Descriptor<Application> {
 

--- a/src/main/java/jenkins/plugins/instana/scope/Application.java
+++ b/src/main/java/jenkins/plugins/instana/scope/Application.java
@@ -1,0 +1,30 @@
+package jenkins.plugins.instana.scope;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+
+public class Application extends AbstractDescribableImpl<Application> {
+
+	private String name;
+
+	@DataBoundConstructor
+	public Application(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Extension
+	public static final class DescriptorImpl extends Descriptor<Application> {
+
+		@Override
+		public String getDisplayName() {
+			return "Application";
+		}
+	}
+}

--- a/src/main/java/jenkins/plugins/instana/scope/Service.java
+++ b/src/main/java/jenkins/plugins/instana/scope/Service.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.instana.scope;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
@@ -19,6 +20,7 @@ public class Service extends AbstractDescribableImpl<Service> {
 		return name;
 	}
 
+	@Symbol("service")
 	@Extension
 	public static final class DescriptorImpl extends Descriptor<Service> {
 

--- a/src/main/java/jenkins/plugins/instana/scope/Service.java
+++ b/src/main/java/jenkins/plugins/instana/scope/Service.java
@@ -1,0 +1,30 @@
+package jenkins.plugins.instana.scope;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+
+public class Service extends AbstractDescribableImpl<Service> {
+
+	private String name;
+
+	@DataBoundConstructor
+	public Service(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Extension
+	public static final class DescriptorImpl extends Descriptor<Service> {
+
+		@Override
+		public String getDisplayName() {
+			return "Service";
+		}
+	}
+}

--- a/src/main/resources/jenkins/plugins/instana/ReleaseMarker/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/ReleaseMarker/config.jelly
@@ -7,7 +7,7 @@
 		<f:textbox/>
 	</f:entry>
 	<f:entry title="Service name">
-		<f:repeatableProperty field="serviceNames">
+		<f:repeatableProperty field="services">
 			<f:entry title="">
 				<div align="right">
 					<f:repeatableDeleteButton/>
@@ -16,7 +16,7 @@
 		</f:repeatableProperty>
 	</f:entry>
 	<f:entry title="Application name">
-		<f:repeatableProperty field="applicationNames">
+		<f:repeatableProperty field="applications">
 			<f:entry title="">
 				<div align="right">
 					<f:repeatableDeleteButton/>

--- a/src/main/resources/jenkins/plugins/instana/ReleaseMarker/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/ReleaseMarker/config.jelly
@@ -1,9 +1,27 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 	<f:entry field="releaseName" title="Release name">
-		<f:textbox />
+		<f:textbox/>
 	</f:entry>
 	<f:entry field="releaseStartTimestamp" title="Start timestamp">
-		<f:textbox />
+		<f:textbox/>
+	</f:entry>
+	<f:entry title="Service name">
+		<f:repeatableProperty field="serviceNames">
+			<f:entry title="">
+				<div align="right">
+					<f:repeatableDeleteButton/>
+				</div>
+			</f:entry>
+		</f:repeatableProperty>
+	</f:entry>
+	<f:entry title="Application name">
+		<f:repeatableProperty field="applicationNames">
+			<f:entry title="">
+				<div align="right">
+					<f:repeatableDeleteButton/>
+				</div>
+			</f:entry>
+		</f:repeatableProperty>
 	</f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/instana/ReleaseMarkerStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/ReleaseMarkerStep/config.jelly
@@ -7,7 +7,7 @@
 		<f:textbox />
 	</f:entry>
 	<f:entry title="Service name">
-		<f:repeatableProperty field="serviceNames">
+		<f:repeatableProperty field="services">
 			<f:entry title="">
 				<div align="right">
 					<f:repeatableDeleteButton/>
@@ -16,7 +16,7 @@
 		</f:repeatableProperty>
 	</f:entry>
 	<f:entry title="Application name">
-		<f:repeatableProperty field="applicationNames">
+		<f:repeatableProperty field="applications">
 			<f:entry title="">
 				<div align="right">
 					<f:repeatableDeleteButton/>

--- a/src/main/resources/jenkins/plugins/instana/ReleaseMarkerStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/ReleaseMarkerStep/config.jelly
@@ -6,4 +6,22 @@
 	<f:entry field="releaseStartTimestamp" title="Start timestamp">
 		<f:textbox />
 	</f:entry>
+	<f:entry title="Service name">
+		<f:repeatableProperty field="serviceNames">
+			<f:entry title="">
+				<div align="right">
+					<f:repeatableDeleteButton/>
+				</div>
+			</f:entry>
+		</f:repeatableProperty>
+	</f:entry>
+	<f:entry title="Application name">
+		<f:repeatableProperty field="applicationNames">
+			<f:entry title="">
+				<div align="right">
+					<f:repeatableDeleteButton/>
+				</div>
+			</f:entry>
+		</f:repeatableProperty>
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/instana/scope/Application/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/scope/Application/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry field="name" title="Name">
+		<f:textbox />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/instana/scope/Service/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/scope/Service/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry field="name" title="Name">
+		<f:textbox />
+	</f:entry>
+</j:jelly>

--- a/src/test/java/jenkins/plugins/instana/Registers.java
+++ b/src/test/java/jenkins/plugins/instana/Registers.java
@@ -1,18 +1,28 @@
 package jenkins.plugins.instana;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
+import org.apache.commons.collections.ListUtils;
 import org.apache.http.entity.ContentType;
 import org.eclipse.jetty.server.Request;
+import org.junit.Test;
 
 import jenkins.plugins.instana.ReleaseMarkerTestBase.SimpleHandler;
 
@@ -21,7 +31,7 @@ import jenkins.plugins.instana.ReleaseMarkerTestBase.SimpleHandler;
  */
 public class Registers {
 
-	static void registerReleaseEndpointChecker(final String name, final String timestamp, final String apiToken)
+	static void registerReleaseEndpointChecker(final String name, final List<String> serviceNames, final List<String> applicationNames, final String timestamp, final String apiToken)
 	{
 		registerHandler("/api/releases", HttpMode.POST,new SimpleHandler() {
 			@Override
@@ -30,6 +40,14 @@ public class Registers {
 				final JSONObject jsonObject = JSONObject.fromObject(body);
 				assertEquals(jsonObject.getString("name"),name);
 				assertEquals(jsonObject.getString("start"),timestamp);
+				if (serviceNames != null) {
+					JSONArray services = jsonObject.getJSONArray("services");
+					assertArrayEquals(services.stream().map(o -> ((JSONObject)o).get("name")).toArray(), serviceNames.toArray());
+				}
+				if (applicationNames != null) {
+					JSONArray applications = jsonObject.getJSONArray("applications");
+					assertArrayEquals(applications.stream().map(o -> ((JSONObject)o).get("name")).toArray(), applicationNames.toArray());
+				}
 
 				Enumeration<String> authHeaders = request.getHeaders("Authorization");
 				String authHeaderValue = authHeaders.nextElement();
@@ -44,6 +62,11 @@ public class Registers {
 				body(response,200,ContentType.APPLICATION_JSON,jsonObject.toString());
 			}
 		});
+	}
+
+	static void registerReleaseEndpointChecker(final String name, final String timestamp, final String apiToken)
+	{
+		registerReleaseEndpointChecker(name, null, null, timestamp, apiToken);
 	}
 
 	static void registerAlways200()
@@ -90,5 +113,26 @@ public class Registers {
 
 	private static void registerHandler(String target, HttpMode method, SimpleHandler handler) {
 		ReleaseMarkerTestBase.registerHandler(target, method, handler);
+	}
+
+
+	@Test
+	public void tryList() {
+		List<String> appNames = Arrays.asList("one", "two", "three", "four");
+		List<String> reqNames = Arrays.asList("two", "FouR", "five");
+
+		List<String> collect = appNames.stream().filter(name -> containsIgnoreCase(reqNames, name)).collect(Collectors.toList());
+		System.out.println(collect);
+		System.out.println(ListUtils.intersection(appNames, reqNames));
+		System.out.println(Collections.disjoint(appNames, reqNames));
+	}
+
+	private boolean containsIgnoreCase(Collection<String> coll, String t) {
+		for (String c : coll) {
+			if (c.equalsIgnoreCase(t)) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerRoundtripTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerRoundtripTest.java
@@ -1,5 +1,7 @@
 package jenkins.plugins.instana;
 
+import java.util.Collections;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -19,6 +21,39 @@ public class ReleaseMarkerRoundtripTest {
 		project = jenkins.configRoundtrip(project);
 
 		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName");
+		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
+	}
+
+	@Test
+	public void testConfigRoundtripWithService() throws Exception
+	{
+		FreeStyleProject project = jenkins.createFreeStyleProject();
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", Collections.singletonList("testServiceName"), null));
+		project = jenkins.configRoundtrip(project);
+
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", Collections.singletonList("testServiceName"), null);
+		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
+	}
+
+	@Test
+	public void testConfigRoundtripWithApplication() throws Exception
+	{
+		FreeStyleProject project = jenkins.createFreeStyleProject();
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", null, Collections.singletonList("testApplicationName")));
+		project = jenkins.configRoundtrip(project);
+
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", null, Collections.singletonList("testApplicationName"));
+		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
+	}
+
+	@Test
+	public void testConfigRoundtripWithServiceAndApplication() throws Exception
+	{
+		FreeStyleProject project = jenkins.createFreeStyleProject();
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", Collections.singletonList("testServiceName"), Collections.singletonList("testApplicationName")));
+		project = jenkins.configRoundtrip(project);
+
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", Collections.singletonList("testServiceName"), Collections.singletonList("testApplicationName"));
 		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
 	}
 }

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerRoundtripTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerRoundtripTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import hudson.model.FreeStyleProject;
+import jenkins.plugins.instana.scope.Application;
+import jenkins.plugins.instana.scope.Service;
 
 public class ReleaseMarkerRoundtripTest {
 
@@ -28,10 +30,10 @@ public class ReleaseMarkerRoundtripTest {
 	public void testConfigRoundtripWithService() throws Exception
 	{
 		FreeStyleProject project = jenkins.createFreeStyleProject();
-		project.getBuildersList().add(new ReleaseMarker("testReleaseName", Collections.singletonList("testServiceName"), null));
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", Collections.singletonList(new Service("testServiceName")), null));
 		project = jenkins.configRoundtrip(project);
 
-		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", Collections.singletonList("testServiceName"), null);
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", Collections.singletonList(new Service("testServiceName")), null);
 		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
 	}
 
@@ -39,10 +41,10 @@ public class ReleaseMarkerRoundtripTest {
 	public void testConfigRoundtripWithApplication() throws Exception
 	{
 		FreeStyleProject project = jenkins.createFreeStyleProject();
-		project.getBuildersList().add(new ReleaseMarker("testReleaseName", null, Collections.singletonList("testApplicationName")));
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", null, Collections.singletonList(new Application("testApplicationName"))));
 		project = jenkins.configRoundtrip(project);
 
-		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", null, Collections.singletonList("testApplicationName"));
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", null, Collections.singletonList(new Application("testApplicationName")));
 		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
 	}
 
@@ -50,10 +52,10 @@ public class ReleaseMarkerRoundtripTest {
 	public void testConfigRoundtripWithServiceAndApplication() throws Exception
 	{
 		FreeStyleProject project = jenkins.createFreeStyleProject();
-		project.getBuildersList().add(new ReleaseMarker("testReleaseName", Collections.singletonList("testServiceName"), Collections.singletonList("testApplicationName")));
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", Collections.singletonList(new Service("testServiceName")), Collections.singletonList(new Application("testApplicationName"))));
 		project = jenkins.configRoundtrip(project);
 
-		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", Collections.singletonList("testServiceName"), Collections.singletonList("testApplicationName"));
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", Collections.singletonList(new Service("testServiceName")), Collections.singletonList(new Application("testApplicationName")));
 		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
 	}
 }

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerStepTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerStepTest.java
@@ -5,6 +5,9 @@ import static jenkins.plugins.instana.Registers.registerFailedAuthEndpoint;
 import static jenkins.plugins.instana.Registers.registerReleaseEndpointChecker;
 import static jenkins.plugins.instana.Registers.registerTimeout;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -21,7 +24,7 @@ public class ReleaseMarkerStepTest extends ReleaseMarkerTestBase {
 	public TemporaryFolder folder = new TemporaryFolder();
 
 	@Test
-	public void correctStepDefinitonWithAllParamatersSetTest() throws Exception {
+	public void correctStepDefinitonWithParametersSetTest() throws Exception {
 		// Prepare the server
 		registerReleaseEndpointChecker("testReleaseName", "123456787689", TEST_API_TOKEN);
 
@@ -29,6 +32,30 @@ public class ReleaseMarkerStepTest extends ReleaseMarkerTestBase {
 		WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
 		proj.setDefinition(new CpsFlowDefinition(
 				"def response = releaseMarker releaseName: 'testReleaseName', releaseStartTimestamp: '123456787689' \n" +
+						"println('Status: '+response.status)\n" +
+						"println('Response: '+response.content)\n",
+				true));
+
+		// Execute the build
+		WorkflowRun run = proj.scheduleBuild2(0).get();
+
+		// Check expectations
+		j.assertBuildStatusSuccess(run);
+		j.assertLogContains("Status: 200", run);
+	}
+
+	@Test
+	public void correctStepDefinitonWithAllParametersSetTest() throws Exception {
+		// Prepare the server
+		registerReleaseEndpointChecker("testReleaseName", Arrays.asList("testServiceName1", "testServiceName2"),
+				Arrays.asList("testApplicationName1", "testApplicationName2"), "123456787689", TEST_API_TOKEN);
+
+		// Configure the build
+		WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
+		proj.setDefinition(new CpsFlowDefinition(
+				"def response = releaseMarker releaseName: 'testReleaseName', releaseStartTimestamp: '123456787689', " +
+						"serviceNames: ['testServiceName1', 'testServiceName2'], " +
+						"applicationNames: ['testApplicationName1', 'testApplicationName2'] \n" +
 						"println('Status: '+response.status)\n" +
 						"println('Response: '+response.content)\n",
 				true));

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerStepTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerStepTest.java
@@ -54,8 +54,8 @@ public class ReleaseMarkerStepTest extends ReleaseMarkerTestBase {
 		WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
 		proj.setDefinition(new CpsFlowDefinition(
 				"def response = releaseMarker releaseName: 'testReleaseName', releaseStartTimestamp: '123456787689', " +
-						"serviceNames: ['testServiceName1', 'testServiceName2'], " +
-						"applicationNames: ['testApplicationName1', 'testApplicationName2'] \n" +
+						"services: [service(name:'testServiceName1'), service(name:'testServiceName2')], " +
+						"applications: [application('testApplicationName1'), application('testApplicationName2')] \n" +
 						"println('Status: '+response.status)\n" +
 						"println('Response: '+response.content)\n",
 				true));

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerTest.java
@@ -4,6 +4,8 @@ import static jenkins.plugins.instana.Registers.registerAlways200;
 import static jenkins.plugins.instana.Registers.registerReleaseEndpointChecker;
 import static jenkins.plugins.instana.Registers.registerTimeout;
 
+import java.util.Arrays;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -25,6 +27,8 @@ public class ReleaseMarkerTest extends ReleaseMarkerTestBase {
 		// Prepare ReleaseEvent
 		ReleaseMarker releaseMarker = new ReleaseMarker("testReleaseName");
 		releaseMarker.setReleaseStartTimestamp("123456787689");
+		releaseMarker.setApplicationNames(Arrays.asList("application1", "application2"));
+		releaseMarker.setServiceNames(Arrays.asList("service1", "service2"));
 
 		// Run build
 		FreeStyleProject project = j.createFreeStyleProject();
@@ -33,7 +37,9 @@ public class ReleaseMarkerTest extends ReleaseMarkerTestBase {
 
 		// Check expectations
 		j.assertBuildStatusSuccess(build);
-		j.assertLogContains("{\"name\":\"testReleaseName\",\"start\":\"123456787689\"}", build);
+		j.assertLogContains("\"name\":\"testReleaseName\",\"start\":\"123456787689\"", build);
+		j.assertLogContains("\"services\":[{\"name\":\"service1\"},{\"name\":\"service2\"}]," +
+				"\"applications\":[{\"name\":\"application1\"},{\"name\":\"application2\"}]", build);
 		j.assertLogContains("200", build);
 	}
 

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerTest.java
@@ -13,6 +13,8 @@ import org.junit.rules.TemporaryFolder;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
+import jenkins.plugins.instana.scope.Application;
+import jenkins.plugins.instana.scope.Service;
 
 public class ReleaseMarkerTest extends ReleaseMarkerTestBase {
 
@@ -27,8 +29,8 @@ public class ReleaseMarkerTest extends ReleaseMarkerTestBase {
 		// Prepare ReleaseEvent
 		ReleaseMarker releaseMarker = new ReleaseMarker("testReleaseName");
 		releaseMarker.setReleaseStartTimestamp("123456787689");
-		releaseMarker.setApplicationNames(Arrays.asList("application1", "application2"));
-		releaseMarker.setServiceNames(Arrays.asList("service1", "service2"));
+		releaseMarker.setApplicationNames(Arrays.asList(new Application("application1"), new Application("application2")));
+		releaseMarker.setServiceNames(Arrays.asList(new Service("service1"), new Service("service2")));
 
 		// Run build
 		FreeStyleProject project = j.createFreeStyleProject();

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerTest.java
@@ -29,8 +29,8 @@ public class ReleaseMarkerTest extends ReleaseMarkerTestBase {
 		// Prepare ReleaseEvent
 		ReleaseMarker releaseMarker = new ReleaseMarker("testReleaseName");
 		releaseMarker.setReleaseStartTimestamp("123456787689");
-		releaseMarker.setApplicationNames(Arrays.asList(new Application("application1"), new Application("application2")));
-		releaseMarker.setServiceNames(Arrays.asList(new Service("service1"), new Service("service2")));
+		releaseMarker.setApplications(Arrays.asList(new Application("application1"), new Application("application2")));
+		releaseMarker.setServices(Arrays.asList(new Service("service1"), new Service("service2")));
 
 		// Run build
 		FreeStyleProject project = j.createFreeStyleProject();


### PR DESCRIPTION
# Why

The upcoming release of Instana will feature the possibility to have scoped release markers. The supported scopes are `applications` and `service`.

# What

Add the two new optional parameters named `services` and `applications` to ReleaseMarker and ReleaseMarkerStep. Add test cases which cover cases with services and/or applications set.

Example usage with scopes:
```
releaseMarker releaseName: "Release 4711", services: [service(name: "my-service-1"), service(name: "my-service-2")]
releaseMarker releaseName: "Release 4711", applications: [application(name: "My Application")]
```