### PR TITLE
Application scoped services

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ releaseMarker releaseName: "Release 4711", applications: [application (name: "My
 releaseMarker releaseName: "Release 4711", applications: [application (name: "My Application-1"), application (name: "My Application-2")]
 ```
 
+```groovy
+// service with scope of a single application
+releaseMarker releaseName: "Release 4711", services: [service (name: "my-service", scopedTo: scopedTo (applications: [application ('My Application-1')]))]
+
+// service with scope of multiple applications
+releaseMarker releaseName: "Release 4711", services: [service (name: "my-service", scopedTo: scopedTo (applications: [application (name: "My Application-1"), application (name: "My Application-2")]))]
+```

--- a/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
+++ b/src/main/java/jenkins/plugins/instana/HttpRequestExecution.java
@@ -56,6 +56,18 @@ public class HttpRequestExecution extends MasterToSlaveCallable<ResponseContentS
 			for (Service service : http.getServices()) {
 				JSONObject serviceJson = new JSONObject();
 				serviceJson.put("name", service.getName());
+				// application scoped
+				if (service.getScopedTo() != null && service.getScopedTo().getApplications() != null) {
+					JSONObject scopedTo = new JSONObject();
+					List<JSONObject> applications = new ArrayList<>();
+					for (Application application : service.getScopedTo().getApplications()) {
+						JSONObject applicationJson = new JSONObject();
+						applicationJson.put("name", application.getName());
+						applications.add(applicationJson);
+					}
+					scopedTo.put("applications", applications);
+					serviceJson.put("scopedTo", scopedTo);
+				}
 				services.add(serviceJson);
 			}
 			jsonObject.put("services", services);

--- a/src/main/java/jenkins/plugins/instana/scope/ScopedTo.java
+++ b/src/main/java/jenkins/plugins/instana/scope/ScopedTo.java
@@ -1,0 +1,35 @@
+package jenkins.plugins.instana.scope;
+
+import java.util.List;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+
+public class ScopedTo extends AbstractDescribableImpl<ScopedTo> {
+
+	private List<Application> applications;
+
+	@DataBoundConstructor
+	public ScopedTo(List<Application> applications) {
+		this.applications = applications;
+	}
+
+	public List<Application> getApplications() {
+		return applications;
+	}
+
+	@Symbol("scopedTo")
+	@Extension
+	public static final class DescriptorImpl extends Descriptor<ScopedTo> {
+
+		@Override
+		public String getDisplayName() {
+			return "ScopedTo";
+		}
+	}
+
+}

--- a/src/main/java/jenkins/plugins/instana/scope/Service.java
+++ b/src/main/java/jenkins/plugins/instana/scope/Service.java
@@ -2,6 +2,7 @@ package jenkins.plugins.instana.scope;
 
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
@@ -11,13 +12,24 @@ public class Service extends AbstractDescribableImpl<Service> {
 
 	private String name;
 
+	private ScopedTo scopedTo;
+
 	@DataBoundConstructor
 	public Service(String name) {
 		this.name = name;
 	}
 
+	@DataBoundSetter
+	public void setScopedTo(ScopedTo scopedTo) {
+		this.scopedTo = scopedTo;
+	}
+
 	public String getName() {
 		return name;
+	}
+
+	public ScopedTo getScopedTo() {
+		return scopedTo;
 	}
 
 	@Symbol("service")

--- a/src/main/resources/jenkins/plugins/instana/ReleaseMarker/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/ReleaseMarker/config.jelly
@@ -1,10 +1,10 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 	<f:entry field="releaseName" title="Release name">
-		<f:textbox/>
+		<f:textbox />
 	</f:entry>
 	<f:entry field="releaseStartTimestamp" title="Start timestamp">
-		<f:textbox/>
+		<f:textbox />
 	</f:entry>
 	<f:entry title="Service name">
 		<f:repeatableProperty field="services">

--- a/src/main/resources/jenkins/plugins/instana/scope/ScopedTo/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/scope/ScopedTo/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="Application name">
+		<f:repeatableProperty field="applications">
+			<f:entry title="">
+				<div align="right">
+					<f:repeatableDeleteButton/>
+				</div>
+			</f:entry>
+		</f:repeatableProperty>
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/instana/scope/Service/config.jelly
+++ b/src/main/resources/jenkins/plugins/instana/scope/Service/config.jelly
@@ -3,4 +3,7 @@
 	<f:entry field="name" title="Name">
 		<f:textbox />
 	</f:entry>
+	<f:entry title="Scoped to applications">
+		<f:optionalProperty field="scopedTo" />
+	</f:entry>
 </j:jelly>

--- a/src/test/java/jenkins/plugins/instana/Registers.java
+++ b/src/test/java/jenkins/plugins/instana/Registers.java
@@ -25,13 +25,15 @@ import org.eclipse.jetty.server.Request;
 import org.junit.Test;
 
 import jenkins.plugins.instana.ReleaseMarkerTestBase.SimpleHandler;
+import jenkins.plugins.instana.scope.Application;
+import jenkins.plugins.instana.scope.Service;
 
 /**
  * @author Janario Oliveira
  */
 public class Registers {
 
-	static void registerReleaseEndpointChecker(final String name, final List<String> serviceNames, final List<String> applicationNames, final String timestamp, final String apiToken)
+	static void registerReleaseEndpointChecker(final String name, final List<Service> services, final List<Application> applications, final String timestamp, final String apiToken)
 	{
 		registerHandler("/api/releases", HttpMode.POST,new SimpleHandler() {
 			@Override
@@ -40,13 +42,13 @@ public class Registers {
 				final JSONObject jsonObject = JSONObject.fromObject(body);
 				assertEquals(jsonObject.getString("name"),name);
 				assertEquals(jsonObject.getString("start"),timestamp);
-				if (serviceNames != null) {
+				if (services != null) {
 					JSONArray services = jsonObject.getJSONArray("services");
-					assertArrayEquals(services.stream().map(o -> ((JSONObject)o).get("name")).toArray(), serviceNames.toArray());
+					assertArrayEquals(services.stream().map(o -> (JSONObject)o).toArray(), services.toArray());
 				}
-				if (applicationNames != null) {
+				if (applications != null) {
 					JSONArray applications = jsonObject.getJSONArray("applications");
-					assertArrayEquals(applications.stream().map(o -> ((JSONObject)o).get("name")).toArray(), applicationNames.toArray());
+					assertArrayEquals(applications.stream().map(o -> (JSONObject)o).toArray(), applications.toArray());
 				}
 
 				Enumeration<String> authHeaders = request.getHeaders("Authorization");

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerRoundtripTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerRoundtripTest.java
@@ -8,6 +8,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import hudson.model.FreeStyleProject;
 import jenkins.plugins.instana.scope.Application;
+import jenkins.plugins.instana.scope.ScopedTo;
 import jenkins.plugins.instana.scope.Service;
 
 public class ReleaseMarkerRoundtripTest {
@@ -56,6 +57,19 @@ public class ReleaseMarkerRoundtripTest {
 		project = jenkins.configRoundtrip(project);
 
 		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", Collections.singletonList(new Service("testServiceName")), Collections.singletonList(new Application("testApplicationName")));
+		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
+	}
+
+	@Test
+	public void testConfigRoundtripWithApplicationScopedService() throws Exception
+	{
+		FreeStyleProject project = jenkins.createFreeStyleProject();
+		Service service = new Service("testServiceName");
+		service.setScopedTo(new ScopedTo(Collections.singletonList(new Application("testApplicationName"))));
+		project.getBuildersList().add(new ReleaseMarker("testReleaseName", Collections.singletonList(service), null));
+		project = jenkins.configRoundtrip(project);
+
+		ReleaseMarker myStepBuilder = new ReleaseMarker("testReleaseName", Collections.singletonList(service), null);
 		jenkins.assertEqualDataBoundBeans(myStepBuilder, project.getBuildersList().get(0));
 	}
 }

--- a/src/test/java/jenkins/plugins/instana/ReleaseMarkerStepTest.java
+++ b/src/test/java/jenkins/plugins/instana/ReleaseMarkerStepTest.java
@@ -16,6 +16,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import hudson.model.Result;
+import jenkins.plugins.instana.scope.Application;
+import jenkins.plugins.instana.scope.ScopedTo;
+import jenkins.plugins.instana.scope.Service;
 
 
 public class ReleaseMarkerStepTest extends ReleaseMarkerTestBase {
@@ -46,15 +49,20 @@ public class ReleaseMarkerStepTest extends ReleaseMarkerTestBase {
 
 	@Test
 	public void correctStepDefinitonWithAllParametersSetTest() throws Exception {
+		Service scopedService = new Service("testServiceName3");
+		scopedService.setScopedTo(new ScopedTo(Collections.singletonList(new Application("testApplication1"))));
 		// Prepare the server
-		registerReleaseEndpointChecker("testReleaseName", Arrays.asList("testServiceName1", "testServiceName2"),
-				Arrays.asList("testApplicationName1", "testApplicationName2"), "123456787689", TEST_API_TOKEN);
+		registerReleaseEndpointChecker("testReleaseName",
+				Arrays.asList(new Service("testServiceName1"), new Service("testServiceName2"), scopedService),
+				Arrays.asList(new Application("testApplicationName1"), new Application("testApplicationName2")),
+				"123456787689", TEST_API_TOKEN);
 
 		// Configure the build
 		WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
 		proj.setDefinition(new CpsFlowDefinition(
 				"def response = releaseMarker releaseName: 'testReleaseName', releaseStartTimestamp: '123456787689', " +
-						"services: [service(name:'testServiceName1'), service(name:'testServiceName2')], " +
+						"services: [service(name:'testServiceName1'), service(name:'testServiceName2'), " +
+						"	service(name:'testServiceName3', scopedTo:scopedTo(applications:[application('testApplicationName1')]))], " +
 						"applications: [application('testApplicationName1'), application('testApplicationName2')] \n" +
 						"println('Status: '+response.status)\n" +
 						"println('Response: '+response.content)\n",


### PR DESCRIPTION
# Why

The API for release markers supports services which are scoped to one or many applications (https://instana.github.io/openapi/#operation/postRelease). This feature is not supported by the Jenkins plugin.

# What

This PR adds the capability of creating release markers for an application scoped service. The `ScopedTo` part is added to the `Service`.

Example usage:
```
releaseMarker releaseName: "Release 4711", services: [service (name: "my-service", scopedTo: scopedTo (applications: [application ('My Application-1')]))]
```